### PR TITLE
Add starting lines to options snippets to fix the options index page

### DIFF
--- a/docs/faq/options/content/license_mask.md
+++ b/docs/faq/options/content/license_mask.md
@@ -1,4 +1,5 @@
 <!--- This file is a snippet --->
+
 |**license_mask**                           |  **#**  |
 |:------------------------------------------|:-------:|
 | Deactivated/trial/demo mode (*default*)   |    0    |

--- a/docs/faq/options/cpu/break_on_unimplemented_instructions.md
+++ b/docs/faq/options/cpu/break_on_unimplemented_instructions.md
@@ -1,4 +1,5 @@
 <!--- This file is a snippet --->
+
 |**break_on_unimplemented_instructions**|**bool**|
 |:--------------------------------------|:------:|
 | On (*default*)                        | true   |

--- a/docs/faq/options/gpu/render_target_path_d3d12.md
+++ b/docs/faq/options/gpu/render_target_path_d3d12.md
@@ -1,4 +1,5 @@
 Leave this option blank for auto-selection.
+
 |**render_target_path_d3d12**                               |**string**|
 |:----------------------------------------------------------|:--------:|
 | Auto-selection                                            |          |

--- a/docs/faq/options/gpu/vsync.md
+++ b/docs/faq/options/gpu/vsync.md
@@ -1,4 +1,5 @@
 <!--- This file is a snippet --->
+
 |**vsync**         |**bool**|
 |:-----------------|:------:|
 | On (*default*)   |  true  |


### PR DESCRIPTION
This PR adds newlines just below the snippet comment, before the start of tables.

This is necessary to fix the options index page, which does not render them correctly because they start with tables.